### PR TITLE
Add multi-language support (English and Korean)

### DIFF
--- a/I18N_USAGE_GUIDE.md
+++ b/I18N_USAGE_GUIDE.md
@@ -1,0 +1,220 @@
+# i18n (Internationalization) Usage Guide
+
+## Overview
+This guide shows you how to use the i18n system to support multiple languages (English and Korean) in your website.
+
+## Files Structure
+```
+/integrated-project
+  ├── i18n.js              # i18n library
+  ├── i18n-styles.css      # Language switcher styles
+  ├── translations/
+  │   ├── en.json          # English translations
+  │   └── ko.json          # Korean translations
+  └── index.html           # Updated with i18n support
+```
+
+## How to Use in HTML
+
+### Method 1: Using `data-i18n` attribute (for text content)
+```html
+<h1 data-i18n="about.title">Oasis</h1>
+<button data-i18n="injection.button">Start Injection Simulation</button>
+```
+
+### Method 2: Using `data-i18n-html` attribute (for HTML content)
+```html
+<h2 data-i18n="about.description" data-i18n-html>
+  The <strong>oasis</strong> project is...
+</h2>
+```
+
+### Method 3: For placeholder and title attributes
+```html
+<input type="text" data-i18n-placeholder="common.searchPlaceholder">
+<button data-i18n-title="common.closeTooltip">X</button>
+```
+
+## How to Use in JavaScript
+
+### Basic Usage - Translate a string
+```javascript
+// Get a simple translation
+const buttonText = i18n.t('injection.button');
+btn.textContent = buttonText;
+
+// Or directly:
+btn.textContent = i18n.t('knife.dropAgain');
+```
+
+### Before (Original Code):
+```javascript
+btn.textContent = 'Start Injection Simulation';
+depthValue.textContent = depth.toFixed(1) + 'mm';
+result.innerHTML = '<p class="success-message">✓ The knife landed safely on its back!</p>';
+```
+
+### After (With i18n):
+```javascript
+btn.textContent = i18n.t('injection.button');
+depthValue.textContent = depth.toFixed(1) + i18n.t('injection.depth');
+result.innerHTML = '<p class="success-message">' + i18n.t('knife.successMessage') + '</p>';
+```
+
+### Example: Updating Footer Elements
+```javascript
+// Original code in minify.js
+x.innerHTML = '<div id="foot-touch">about oasis</div>';
+
+// Updated with i18n
+x.innerHTML = '<div id="foot-touch" data-i18n="footer.touch">about oasis</div>';
+i18n.translatePage(); // Re-translate after DOM update
+```
+
+### Example: Dynamic Content Creation
+```javascript
+// When creating HTML dynamically, use i18n.t()
+container.innerHTML = `
+    <button id="start-btn">${i18n.t('injection.button')}</button>
+    <div class="depth-display">${i18n.t('injection.depth')}</div>
+`;
+```
+
+### Example: Handling Language Change Events
+```javascript
+// Listen for language changes
+document.addEventListener('languageChanged', function(event) {
+    console.log('Language changed to:', event.detail.lang);
+
+    // Update any dynamic content that wasn't auto-translated
+    updateMyCustomContent();
+});
+```
+
+### Example: Re-translate After DOM Updates
+```javascript
+// After adding new elements to the DOM
+function addNewContent() {
+    const newElement = document.createElement('div');
+    newElement.setAttribute('data-i18n', 'common.loading');
+    newElement.textContent = 'Loading...';
+    document.body.appendChild(newElement);
+
+    // Re-translate the page to pick up new elements
+    i18n.translatePage();
+}
+```
+
+## Updating Your JavaScript Files
+
+### Common Patterns to Update:
+
+#### 1. Button Text
+```javascript
+// Before:
+btn.textContent = 'Drop Again';
+btn.textContent = 'Injecting...';
+
+// After:
+btn.textContent = i18n.t('knife.dropAgain');
+btn.textContent = i18n.t('injection.injecting');
+```
+
+#### 2. innerHTML with Static Text
+```javascript
+// Before:
+footer.innerHTML = '<div>about oasis</div>';
+
+// After:
+footer.innerHTML = '<div data-i18n="footer.about">about oasis</div>';
+i18n.translatePage();
+```
+
+#### 3. Template Literals
+```javascript
+// Before:
+container.innerHTML = \`
+    <h2>Screen Saver</h2>
+    <button>FOR MACINTOSH</button>
+    <button>FOR WINDOWS</button>
+\`;
+
+// After:
+container.innerHTML = \`
+    <h2 data-i18n="footer.screensaver">Screen Saver</h2>
+    <button data-i18n="screensaver.forMac">FOR MACINTOSH</button>
+    <button data-i18n="screensaver.forWin">FOR WINDOWS</button>
+\`;
+i18n.translatePage();
+```
+
+## API Reference
+
+### `i18n.t(key, params)`
+Get a translated string.
+- **key**: Translation key (e.g., 'about.title')
+- **params**: Optional parameters for interpolation
+
+```javascript
+i18n.t('about.title') // Returns: "Oasis" or "오아시스"
+```
+
+### `i18n.switchLanguage(lang)`
+Switch to a different language.
+```javascript
+i18n.switchLanguage('ko'); // Switch to Korean
+i18n.switchLanguage('en'); // Switch to English
+```
+
+### `i18n.translatePage()`
+Re-translate all elements with `data-i18n` attributes.
+```javascript
+i18n.translatePage();
+```
+
+### `i18n.getCurrentLanguage()`
+Get the current language code.
+```javascript
+const currentLang = i18n.getCurrentLanguage(); // Returns: 'en' or 'ko'
+```
+
+## Adding New Translations
+
+1. Open `/translations/en.json` and add your new key:
+```json
+{
+  "mySection": {
+    "newText": "Hello World"
+  }
+}
+```
+
+2. Open `/translations/ko.json` and add the Korean translation:
+```json
+{
+  "mySection": {
+    "newText": "안녕하세요"
+  }
+}
+```
+
+3. Use it in your code:
+```javascript
+const text = i18n.t('mySection.newText');
+```
+
+## Testing
+
+1. Open your website
+2. Click the language switcher buttons (EN / 한국어) in the top-right corner
+3. Verify that all text changes to the selected language
+4. Check browser localStorage to confirm language preference is saved
+5. Refresh the page to ensure the language persists
+
+## Tips
+
+- Always add both English and Korean translations
+- Use descriptive keys (e.g., 'injection.button' not 'btn1')
+- Group related translations together
+- Call `i18n.translatePage()` after dynamically adding HTML with `data-i18n` attributes
+- Use `data-i18n-html` when your translation contains HTML tags

--- a/MULTI_LANGUAGE_SETUP.md
+++ b/MULTI_LANGUAGE_SETUP.md
@@ -1,0 +1,172 @@
+# Multi-Language Support Implementation
+
+## ✅ What's Been Implemented
+
+Your website now supports **2 languages: English (EN) and Korean (한국어)**
+
+### Files Added:
+1. **`i18n.js`** - Internationalization library
+2. **`i18n-styles.css`** - Language switcher styling
+3. **`translations/en.json`** - English translations
+4. **`translations/ko.json`** - Korean translations
+5. **`I18N_USAGE_GUIDE.md`** - Complete usage documentation
+6. **`example-i18n-usage.js`** - Code examples for your JavaScript files
+
+### Files Modified:
+- **`index.html`** - Added language switcher and translation attributes
+
+## 🎯 Features
+
+- ✅ Language switcher in top-right corner (EN / 한국어)
+- ✅ Automatic language detection from localStorage
+- ✅ Language preference persistence across page reloads
+- ✅ Support for HTML content translation
+- ✅ Dynamic JavaScript content translation
+- ✅ Custom events for language change detection
+- ✅ Responsive design for mobile and desktop
+
+## 🚀 How to Use
+
+### 1. HTML Elements (Already Done)
+The HTML has been updated with `data-i18n` attributes:
+```html
+<h1 data-i18n="about.heading">Oasis</h1>
+<button data-i18n="injection.button">Start Injection</button>
+```
+
+### 2. JavaScript Updates (You Need to Do This)
+Update your `minify/minify.js` file to use i18n for dynamic text:
+
+**Before:**
+```javascript
+btn.textContent = 'Start Injection Simulation';
+```
+
+**After:**
+```javascript
+btn.textContent = i18n.t('injection.button');
+```
+
+See `example-i18n-usage.js` for 10+ detailed examples!
+
+## 📋 Next Steps
+
+### Step 1: Update Your JavaScript
+Go through your `minify/minify.js` and update text strings to use `i18n.t()`:
+
+Common patterns to update:
+- `textContent = "text"` → `textContent = i18n.t('key')`
+- `innerHTML = "<div>text</div>"` → Use `data-i18n` attributes + `i18n.translatePage()`
+
+### Step 2: Add Missing Translations
+As you update your JavaScript, you may find text that's not in the translation files yet:
+
+1. Open `translations/en.json`
+2. Add your new translation key
+3. Open `translations/ko.json`
+4. Add the Korean translation
+5. Use it with `i18n.t('your.new.key')`
+
+### Step 3: Test
+1. Open your website
+2. Click the language switcher (EN / 한국어)
+3. Verify all text changes
+4. Check that the language persists after page reload
+
+## 📚 Documentation
+
+- **`I18N_USAGE_GUIDE.md`** - Complete API reference and usage guide
+- **`example-i18n-usage.js`** - 10+ code examples showing how to update your JS
+
+## 🔍 Key Locations to Update
+
+Based on your `minify.js`, these areas need translation updates:
+
+1. **Injection simulation** (lines ~918, 940, 978, 987)
+   - "Injecting...", "Start Injection Simulation", "mm"
+
+2. **Knife drop** (lines ~1771, 1773)
+   - "Drop Again", success messages
+
+3. **Footer elements** (lines ~3490, 3547, 3550-3551)
+   - "about oasis", "screen saver", "share", "fullscreen", "exit fullscreen"
+
+4. **Share box** (line ~3490)
+   - "facebook", "twitter", "google plus", "pinterest", "tumblr"
+
+5. **Screensaver** (line ~3528)
+   - "FOR MACINTOSH", "FOR WINDOWS", Flash Player message
+
+## 💡 Quick Tips
+
+1. **After creating HTML dynamically**, call `i18n.translatePage()`
+2. **For text content**, use `i18n.t('key')`
+3. **For HTML with tags**, use `data-i18n` + `data-i18n-html` attributes
+4. **Listen for changes** with `document.addEventListener('languageChanged', ...)`
+
+## 🎨 Customization
+
+### Add More Languages
+1. Create `translations/es.json` (Spanish, for example)
+2. Update `i18n.js`: `supportedLanguages: ['en', 'ko', 'es']`
+3. Add button: `<button data-lang="es">ES</button>`
+
+### Style the Language Switcher
+Edit `i18n-styles.css` to customize:
+- Button colors
+- Position
+- Hover effects
+- Mobile responsiveness
+
+## ✨ Example Usage in Your Code
+
+```javascript
+// Simple text
+btn.textContent = i18n.t('injection.button');
+
+// HTML creation with i18n
+container.innerHTML = `
+    <div data-i18n="footer.about">about oasis</div>
+    <button data-i18n="screensaver.forMac">FOR MACINTOSH</button>
+`;
+i18n.translatePage();
+
+// Get current language
+const currentLang = i18n.getCurrentLanguage(); // 'en' or 'ko'
+
+// Switch language programmatically
+i18n.switchLanguage('ko');
+
+// React to language changes
+document.addEventListener('languageChanged', (e) => {
+    console.log('Language changed to:', e.detail.lang);
+});
+```
+
+## 🐛 Troubleshooting
+
+**Problem:** Language doesn't switch
+- Check browser console for errors
+- Verify translation JSON files are accessible
+- Make sure `i18n.js` loads before `minify.js`
+
+**Problem:** Some text doesn't translate
+- Check if the element has `data-i18n` attribute
+- Call `i18n.translatePage()` after adding new DOM elements
+- For JS-generated content, use `i18n.t()` directly
+
+**Problem:** Translation key not found
+- Check the key exists in both `en.json` and `ko.json`
+- Verify the key path is correct (e.g., 'about.title' not 'aboutTitle')
+
+## 📞 Support
+
+For detailed examples and API documentation, see:
+- `I18N_USAGE_GUIDE.md` - Complete guide
+- `example-i18n-usage.js` - Code examples
+
+## 🎉 Summary
+
+You now have a fully functional multi-language system! The HTML is ready to go. You just need to update your JavaScript files to use `i18n.t()` for dynamic content. Follow the examples in `example-i18n-usage.js` to get started.
+
+Happy translating! 🌍

--- a/example-i18n-usage.js
+++ b/example-i18n-usage.js
@@ -1,0 +1,327 @@
+/**
+ * Example: How to Update Your JavaScript to Use i18n
+ *
+ * This file shows examples of common patterns found in your minify.js
+ * and how to update them to support multi-language.
+ */
+
+// ============================================
+// EXAMPLE 1: Simple Button Text
+// ============================================
+
+// BEFORE:
+function startInjection_OLD() {
+    btn.textContent = 'Injecting...';
+    // ... rest of code
+}
+
+// AFTER:
+function startInjection() {
+    btn.textContent = i18n.t('injection.injecting');
+    // ... rest of code
+}
+
+
+// ============================================
+// EXAMPLE 2: Text with Variables/Numbers
+// ============================================
+
+// BEFORE:
+function updateDepth_OLD(depth) {
+    depthValue.textContent = depth.toFixed(1) + 'mm';
+}
+
+// AFTER:
+function updateDepth(depth) {
+    depthValue.textContent = depth.toFixed(1) + i18n.t('injection.depth');
+}
+
+
+// ============================================
+// EXAMPLE 3: innerHTML with HTML Content
+// ============================================
+
+// BEFORE:
+function showResult_OLD() {
+    result.innerHTML = '<p class="success-message">✓ The knife landed safely on its back!</p><p>This demonstrates that knives don\'t always fall point-first. The flat surface provides stability.</p>';
+}
+
+// AFTER:
+function showResult() {
+    result.innerHTML = `
+        <p class="success-message">${i18n.t('knife.successMessage')}</p>
+        <p>${i18n.t('knife.successDescription')}</p>
+    `;
+}
+
+
+// ============================================
+// EXAMPLE 4: Creating DOM Elements with Text
+// ============================================
+
+// BEFORE:
+function createFooter_OLD() {
+    const footer = document.createElement('div');
+    footer.innerHTML = `
+        <div id="foot-touch">about oasis</div>
+        <div id="foot-share">share</div>
+        <div id="foot-full">fullscreen</div>
+    `;
+    return footer;
+}
+
+// AFTER (Method 1: Using i18n.t() in template):
+function createFooter_v1() {
+    const footer = document.createElement('div');
+    footer.innerHTML = `
+        <div id="foot-touch">${i18n.t('footer.touch')}</div>
+        <div id="foot-share">${i18n.t('footer.share')}</div>
+        <div id="foot-full">${i18n.t('footer.fullscreen')}</div>
+    `;
+    return footer;
+}
+
+// AFTER (Method 2: Using data-i18n attributes):
+function createFooter_v2() {
+    const footer = document.createElement('div');
+    footer.innerHTML = `
+        <div id="foot-touch" data-i18n="footer.touch">about oasis</div>
+        <div id="foot-share" data-i18n="footer.share">share</div>
+        <div id="foot-full" data-i18n="footer.fullscreen">fullscreen</div>
+    `;
+
+    // Re-translate to pick up the new elements
+    i18n.translatePage();
+    return footer;
+}
+
+
+// ============================================
+// EXAMPLE 5: Dynamic Footer Share Box
+// ============================================
+
+// BEFORE:
+function createShareBox_OLD() {
+    const box = document.createElement('div');
+    box.innerHTML = `
+        <ul id="foot-share-box">
+            <li id="foot-share-0">facebook</li>
+            <li id="foot-share-1">twitter</li>
+            <li id="foot-share-2">google plus</li>
+            <li id="foot-share-3">pinterest</li>
+            <li id="foot-share-4">tumblr</li>
+        </ul>
+    `;
+    document.body.appendChild(box);
+}
+
+// AFTER:
+function createShareBox() {
+    const box = document.createElement('div');
+    box.innerHTML = `
+        <ul id="foot-share-box">
+            <li id="foot-share-0" data-i18n="share.facebook">facebook</li>
+            <li id="foot-share-1" data-i18n="share.twitter">twitter</li>
+            <li id="foot-share-2" data-i18n="share.googlePlus">google plus</li>
+            <li id="foot-share-3" data-i18n="share.pinterest">pinterest</li>
+            <li id="foot-share-4" data-i18n="share.tumblr">tumblr</li>
+        </ul>
+    `;
+    document.body.appendChild(box);
+
+    // Important: Call translatePage after adding to DOM
+    i18n.translatePage();
+}
+
+
+// ============================================
+// EXAMPLE 6: Fullscreen Text Toggle
+// ============================================
+
+// BEFORE:
+function onFullscreenChange_OLD() {
+    if (document.webkitIsFullScreen) {
+        fullscreenBtn.innerHTML = "exit fullscreen";
+    } else {
+        fullscreenBtn.innerHTML = "fullscreen";
+    }
+}
+
+// AFTER:
+function onFullscreenChange() {
+    if (document.webkitIsFullScreen) {
+        fullscreenBtn.textContent = i18n.t('footer.exitFullscreen');
+    } else {
+        fullscreenBtn.textContent = i18n.t('footer.fullscreen');
+    }
+}
+
+
+// ============================================
+// EXAMPLE 7: Conditional Footer Content
+// ============================================
+
+// BEFORE:
+function initFooter_OLD() {
+    if (CMDetect.isMobile) {
+        x.innerHTML = '<div id="foot-touch">about oasis</div>';
+    } else {
+        x.innerHTML = `
+            <div id="foot-web-about">about oasis</div>
+            <div id="foot-dot-big">•</div>
+            <div id="foot-web-screen">screen saver</div>
+        `;
+    }
+}
+
+// AFTER:
+function initFooter() {
+    if (CMDetect.isMobile) {
+        x.innerHTML = '<div id="foot-touch" data-i18n="footer.touch">about oasis</div>';
+    } else {
+        x.innerHTML = `
+            <div id="foot-web-about" data-i18n="footer.about">about oasis</div>
+            <div id="foot-dot-big">•</div>
+            <div id="foot-web-screen" data-i18n="footer.screensaver">screen saver</div>
+        `;
+    }
+
+    // Re-translate after DOM update
+    i18n.translatePage();
+}
+
+
+// ============================================
+// EXAMPLE 8: Screensaver Content
+// ============================================
+
+// BEFORE:
+function createScreensaver_OLD() {
+    container.innerHTML = `
+        <ul>
+            <li id="ss-button-mac">FOR MACINTOSH</li>
+            <li id="ss-button-win">FOR WINDOWS</li>
+        </ul>
+        <p>You need <a href="http://www.adobe.com/go/getflashplayer" target="_blank">Adobe Flash Player</a> 10.1 or higher to install this screensaver.</p>
+    `;
+}
+
+// AFTER:
+function createScreensaver() {
+    container.innerHTML = `
+        <ul>
+            <li id="ss-button-mac" data-i18n="screensaver.forMac">FOR MACINTOSH</li>
+            <li id="ss-button-win" data-i18n="screensaver.forWin">FOR WINDOWS</li>
+        </ul>
+        <p data-i18n-html="screensaver.flashRequired">
+            You need <a href="http://www.adobe.com/go/getflashplayer" target="_blank">Adobe Flash Player</a> 10.1 or higher to install this screensaver.
+        </p>
+    `;
+
+    i18n.translatePage();
+}
+
+
+// ============================================
+// EXAMPLE 9: Handling Language Change Events
+// ============================================
+
+// Listen for language changes and update custom content
+document.addEventListener('languageChanged', function(event) {
+    console.log('Language changed to:', event.detail.lang);
+
+    // Update any dynamically generated content that wasn't auto-translated
+    updateCustomContent();
+
+    // Update meta tags if needed
+    updateMetaTags(event.detail.lang);
+});
+
+function updateCustomContent() {
+    // Re-fetch or regenerate content that depends on language
+    // Example: update dynamically loaded poster titles
+    const posters = document.querySelectorAll('.poster-title');
+    posters.forEach(poster => {
+        const key = poster.getAttribute('data-i18n-key');
+        if (key) {
+            poster.textContent = i18n.t(key);
+        }
+    });
+}
+
+function updateMetaTags(lang) {
+    // Update HTML lang attribute
+    document.documentElement.setAttribute('lang', lang);
+
+    // Optionally update meta descriptions, titles, etc.
+    if (lang === 'ko') {
+        document.title = '오아시스 - Form Follows Function';
+    } else {
+        document.title = 'Oasis - Form Follows Function';
+    }
+}
+
+
+// ============================================
+// EXAMPLE 10: Best Practice Pattern
+// ============================================
+
+// Complete example showing best practices
+function initializeComponent() {
+    // 1. Create HTML structure with data-i18n attributes
+    const component = document.createElement('div');
+    component.className = 'my-component';
+    component.innerHTML = `
+        <h2 data-i18n="component.title">Title</h2>
+        <p data-i18n="component.description">Description</p>
+        <button id="action-btn" data-i18n="component.actionButton">Click Me</button>
+    `;
+
+    // 2. Add to DOM
+    document.body.appendChild(component);
+
+    // 3. Translate the new content
+    i18n.translatePage();
+
+    // 4. Set up event listeners
+    const btn = document.getElementById('action-btn');
+    btn.addEventListener('click', handleAction);
+
+    // 5. Listen for language changes to update dynamic content
+    document.addEventListener('languageChanged', () => {
+        // Update any content that couldn't use data-i18n
+        updateDynamicContent();
+    });
+}
+
+
+// ============================================
+// QUICK REFERENCE
+// ============================================
+
+/*
+Common i18n Methods:
+
+1. i18n.t(key)
+   - Get translation for a key
+   - Example: i18n.t('about.title')
+
+2. i18n.switchLanguage(lang)
+   - Switch to different language
+   - Example: i18n.switchLanguage('ko')
+
+3. i18n.translatePage()
+   - Re-translate all elements with data-i18n
+   - Call after adding new DOM elements
+
+4. i18n.getCurrentLanguage()
+   - Get current language code
+   - Returns: 'en' or 'ko'
+
+HTML Attributes:
+- data-i18n="key"              -> Sets textContent
+- data-i18n-html               -> Sets innerHTML (use with data-i18n)
+- data-i18n-placeholder="key"  -> Sets placeholder
+- data-i18n-title="key"        -> Sets title attribute
+- data-lang="en"               -> Language switcher button
+*/

--- a/i18n-styles.css
+++ b/i18n-styles.css
@@ -1,0 +1,83 @@
+/* Language Switcher Styles */
+#lang-switcher {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    z-index: 1000;
+    display: flex;
+    gap: 10px;
+}
+
+#lang-switcher button {
+    background: rgba(255, 255, 255, 0.1);
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    color: #fff;
+    padding: 8px 16px;
+    border-radius: 20px;
+    cursor: pointer;
+    font-family: 'Crimson Text', serif;
+    font-size: 14px;
+    font-weight: 600;
+    letter-spacing: 1px;
+    transition: all 0.3s ease;
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+}
+
+#lang-switcher button:hover {
+    background: rgba(255, 255, 255, 0.2);
+    border-color: rgba(255, 255, 255, 0.5);
+    transform: translateY(-2px);
+}
+
+#lang-switcher button.active {
+    background: rgba(255, 255, 255, 0.9);
+    color: #222;
+    border-color: rgba(255, 255, 255, 0.9);
+}
+
+/* Dark header variation */
+.header-black ~ #lang-switcher button {
+    background: rgba(34, 34, 34, 0.1);
+    border-color: rgba(34, 34, 34, 0.3);
+    color: #222;
+}
+
+.header-black ~ #lang-switcher button:hover {
+    background: rgba(34, 34, 34, 0.2);
+    border-color: rgba(34, 34, 34, 0.5);
+}
+
+.header-black ~ #lang-switcher button.active {
+    background: rgba(34, 34, 34, 0.9);
+    color: #fff;
+    border-color: rgba(34, 34, 34, 0.9);
+}
+
+/* Mobile responsiveness */
+@media (max-width: 768px) {
+    #lang-switcher {
+        top: 15px;
+        right: 15px;
+        gap: 8px;
+    }
+
+    #lang-switcher button {
+        padding: 6px 12px;
+        font-size: 12px;
+    }
+}
+
+@media (max-width: 480px) {
+    #lang-switcher {
+        top: 10px;
+        right: 10px;
+        gap: 6px;
+    }
+
+    #lang-switcher button {
+        padding: 5px 10px;
+        font-size: 11px;
+        letter-spacing: 0.5px;
+    }
+}

--- a/i18n.js
+++ b/i18n.js
@@ -1,0 +1,207 @@
+/**
+ * Simple i18n (Internationalization) System
+ * Supports multi-language translation for HTML and JavaScript content
+ */
+
+const i18n = {
+    currentLang: 'en',
+    translations: {},
+    defaultLang: 'en',
+    supportedLanguages: ['en', 'ko'],
+
+    /**
+     * Initialize the i18n system
+     * @param {string} defaultLang - Default language (e.g., 'en', 'ko')
+     */
+    async init(defaultLang = 'en') {
+        this.defaultLang = defaultLang;
+
+        // Get language from localStorage or use default
+        this.currentLang = localStorage.getItem('language') || defaultLang;
+
+        // Load translations
+        await this.loadTranslations(this.currentLang);
+
+        // Translate the page
+        this.translatePage();
+
+        // Attach event listeners for language switchers
+        this.attachLanguageSwitchers();
+
+        // Update HTML lang attribute
+        document.documentElement.setAttribute('lang', this.currentLang);
+    },
+
+    /**
+     * Load translation file for a specific language
+     * @param {string} lang - Language code
+     */
+    async loadTranslations(lang) {
+        try {
+            const response = await fetch(`/translations/${lang}.json`);
+            if (!response.ok) {
+                throw new Error(`Failed to load translations for ${lang}`);
+            }
+            this.translations = await response.json();
+            return true;
+        } catch (error) {
+            console.error('Error loading translations:', error);
+
+            // Fallback to default language if current lang fails
+            if (lang !== this.defaultLang) {
+                console.log(`Falling back to ${this.defaultLang}`);
+                const response = await fetch(`/translations/${this.defaultLang}.json`);
+                this.translations = await response.json();
+                this.currentLang = this.defaultLang;
+            }
+            return false;
+        }
+    },
+
+    /**
+     * Get translation for a key
+     * @param {string} key - Translation key (e.g., 'about.title')
+     * @param {object} params - Optional parameters for interpolation
+     * @returns {string} Translated text
+     */
+    t(key, params = {}) {
+        const keys = key.split('.');
+        let value = this.translations;
+
+        // Navigate through nested object
+        for (const k of keys) {
+            value = value?.[k];
+            if (!value) {
+                console.warn(`Translation key not found: ${key}`);
+                return key;
+            }
+        }
+
+        // Replace parameters if provided
+        if (typeof value === 'string' && Object.keys(params).length > 0) {
+            Object.keys(params).forEach(param => {
+                value = value.replace(new RegExp(`{{${param}}}`, 'g'), params[param]);
+            });
+        }
+
+        return value;
+    },
+
+    /**
+     * Translate all elements with data-i18n attribute
+     */
+    translatePage() {
+        // Translate elements with data-i18n attribute
+        document.querySelectorAll('[data-i18n]').forEach(el => {
+            const key = el.getAttribute('data-i18n');
+            const translation = this.t(key);
+
+            // Check if element should use innerHTML (for HTML content)
+            if (el.hasAttribute('data-i18n-html')) {
+                el.innerHTML = translation;
+            } else {
+                el.textContent = translation;
+            }
+        });
+
+        // Translate elements with data-i18n-placeholder attribute
+        document.querySelectorAll('[data-i18n-placeholder]').forEach(el => {
+            const key = el.getAttribute('data-i18n-placeholder');
+            el.placeholder = this.t(key);
+        });
+
+        // Translate elements with data-i18n-title attribute
+        document.querySelectorAll('[data-i18n-title]').forEach(el => {
+            const key = el.getAttribute('data-i18n-title');
+            el.title = this.t(key);
+        });
+
+        // Update active language button
+        this.updateLanguageButtons();
+    },
+
+    /**
+     * Switch to a different language
+     * @param {string} lang - Language code
+     */
+    async switchLanguage(lang) {
+        if (!this.supportedLanguages.includes(lang)) {
+            console.error(`Language ${lang} is not supported`);
+            return;
+        }
+
+        if (lang === this.currentLang) {
+            return;
+        }
+
+        this.currentLang = lang;
+        localStorage.setItem('language', lang);
+
+        await this.loadTranslations(lang);
+        this.translatePage();
+
+        // Update HTML lang attribute
+        document.documentElement.setAttribute('lang', lang);
+
+        // Trigger custom event for language change
+        const event = new CustomEvent('languageChanged', { detail: { lang } });
+        document.dispatchEvent(event);
+    },
+
+    /**
+     * Attach click event listeners to language switcher buttons
+     */
+    attachLanguageSwitchers() {
+        document.querySelectorAll('[data-lang]').forEach(btn => {
+            btn.addEventListener('click', (e) => {
+                e.preventDefault();
+                const lang = btn.getAttribute('data-lang');
+                this.switchLanguage(lang);
+            });
+        });
+    },
+
+    /**
+     * Update active state of language buttons
+     */
+    updateLanguageButtons() {
+        document.querySelectorAll('[data-lang]').forEach(btn => {
+            const lang = btn.getAttribute('data-lang');
+            if (lang === this.currentLang) {
+                btn.classList.add('active');
+            } else {
+                btn.classList.remove('active');
+            }
+        });
+    },
+
+    /**
+     * Get current language
+     * @returns {string} Current language code
+     */
+    getCurrentLanguage() {
+        return this.currentLang;
+    },
+
+    /**
+     * Check if a language is supported
+     * @param {string} lang - Language code
+     * @returns {boolean}
+     */
+    isLanguageSupported(lang) {
+        return this.supportedLanguages.includes(lang);
+    }
+};
+
+// Auto-initialize when DOM is ready
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => {
+        i18n.init();
+    });
+} else {
+    // DOM is already ready
+    i18n.init();
+}
+
+// Make i18n globally available
+window.i18n = i18n;

--- a/index.html
+++ b/index.html
@@ -45,6 +45,7 @@
     <meta itemprop="image" content="https://fff.cmiscm.com/images/share.png"/>
 
     <link rel="stylesheet" type="text/css" href="minify/minify.css?id=3">
+    <link rel="stylesheet" type="text/css" href="i18n-styles.css">
 
     <style>
 #header.header-white text {
@@ -95,28 +96,34 @@
 
         <div id="header" class="header-black">
   <svg width="70" height="25" viewBox="0 0 70 25">
-    <text x="35" y="18" font-family="Crimson Text, serif" font-weight="600" font-size="22" text-anchor="middle" style="letter-spacing: 2px;">
+    <text x="35" y="18" font-family="Crimson Text, serif" font-weight="600" font-size="22" text-anchor="middle" style="letter-spacing: 2px;" data-i18n="header.title">
       oasis
     </text>
   </svg>
 </div>
+
+        <!-- Language Switcher -->
+        <div id="lang-switcher">
+            <button data-lang="en" title="English">EN</button>
+            <button data-lang="ko" title="한국어">한국어</button>
+        </div>
             <div id="about">
                 <div id="about-right" class="right-pos white">
                     <div id="about-close-bt" class="buttons close-pos"></div>
                 </div>
 
                 <div id="about-contents">
-                    <h1>Oasis</h1>
-                    <h2>The <span class="about-bold">oasis</span> project is a collection of "interactive experiences", each experience has its own unique design and functionality. The project intends to help alleviate symptoms and reduce reactions of specific phobias on the website, with each interactive experience represented by a poster. By clicking on a poster, an interactive experience opens up specialized to a certain type of phobia.</h2>
+                    <h1 data-i18n="about.heading">Oasis</h1>
+                    <h2 data-i18n="about.description" data-i18n-html>The <span class="about-bold">oasis</span> project is a collection of "interactive experiences", each experience has its own unique design and functionality. The project intends to help alleviate symptoms and reduce reactions of specific phobias on the website, with each interactive experience represented by a poster. By clicking on a poster, an interactive experience opens up specialized to a certain type of phobia.</h2>
                     <p>
-                        If you want to contact me check out my<br>
-                        <a href="http://Oasis.space/" target="_blank"><span id="link-website" class="about-link">website</span></a> ・
+                        <span data-i18n="about.contact">If you want to contact me check out my</span><br>
+                        <a href="http://Oasis.space/" target="_blank"><span id="link-website" class="about-link" data-i18n="about.website">website</span></a> ・
                     </p>
-                    <span class="copyright">
+                    <span class="copyright" data-i18n="about.copyright">
                             Copyright © 2025 cute centipede . All rights reserved.
                         </span>
                      <div class="press">
-                        <a href="https://www.minjok.hs.kr/" class="chrome-ex" target="_blank">This is a KMLA project</a><span>\</a>
+                        <a href="https://www.minjok.hs.kr/" class="chrome-ex" target="_blank" data-i18n="about.kmla">This is a KMLA project</a><span>\</a>
                     </div>
                 </div>
             </div>
@@ -128,6 +135,9 @@
 
     <!-- Three.js for 3D game -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+
+    <!-- i18n (Internationalization) Library -->
+    <script src="i18n.js"></script>
 
     <script src="minify/minify.js?id=3"></script>
 

--- a/translations/en.json
+++ b/translations/en.json
@@ -1,0 +1,52 @@
+{
+  "header": {
+    "title": "oasis"
+  },
+  "about": {
+    "title": "Oasis",
+    "heading": "Oasis",
+    "description": "The <strong>oasis</strong> project is a collection of \"interactive experiences\", each experience has its own unique design and functionality. The project intends to help alleviate symptoms and reduce reactions of specific phobias on the website, with each interactive experience represented by a poster. By clicking on a poster, an interactive experience opens up specialized to a certain type of phobia.",
+    "contact": "If you want to contact me check out my",
+    "website": "website",
+    "copyright": "Copyright © 2025 cute centipede . All rights reserved.",
+    "kmla": "This is a KMLA project"
+  },
+  "footer": {
+    "about": "about oasis",
+    "screensaver": "screen saver",
+    "share": "share",
+    "shareToSns": "share to sns",
+    "fullscreen": "fullscreen",
+    "exitFullscreen": "exit fullscreen",
+    "touch": "about oasis"
+  },
+  "share": {
+    "facebook": "facebook",
+    "twitter": "twitter",
+    "googlePlus": "google plus",
+    "pinterest": "pinterest",
+    "tumblr": "tumblr"
+  },
+  "injection": {
+    "button": "Start Injection Simulation",
+    "injecting": "Injecting...",
+    "depth": "mm",
+    "checkmark": "✓"
+  },
+  "knife": {
+    "dropAgain": "Drop Again",
+    "successMessage": "✓ The knife landed safely on its back!",
+    "successDescription": "This demonstrates that knives don't always fall point-first. The flat surface provides stability.",
+    "text": "Drop the knife and see how it lands"
+  },
+  "screensaver": {
+    "forMac": "FOR MACINTOSH",
+    "forWin": "FOR WINDOWS",
+    "flashRequired": "You need Adobe Flash Player 10.1 or higher to install this screensaver.",
+    "getFlash": "Adobe Flash Player"
+  },
+  "common": {
+    "loading": "Loading...",
+    "close": "Close"
+  }
+}

--- a/translations/ko.json
+++ b/translations/ko.json
@@ -1,0 +1,52 @@
+{
+  "header": {
+    "title": "오아시스"
+  },
+  "about": {
+    "title": "오아시스",
+    "heading": "오아시스",
+    "description": "<strong>오아시스</strong> 프로젝트는 \"대화형 경험\"의 모음으로, 각 경험은 고유한 디자인과 기능을 가지고 있습니다. 이 프로젝트는 웹사이트에서 특정 공포증의 증상을 완화하고 반응을 줄이는 데 도움을 주기 위한 것이며, 각 대화형 경험은 포스터로 표현됩니다. 포스터를 클릭하면 특정 공포증에 특화된 대화형 경험이 열립니다.",
+    "contact": "연락을 원하시면 제",
+    "website": "웹사이트",
+    "copyright": "저작권 © 2025 cute centipede . 모든 권리 보유.",
+    "kmla": "민족사관고등학교 프로젝트입니다"
+  },
+  "footer": {
+    "about": "오아시스 소개",
+    "screensaver": "화면 보호기",
+    "share": "공유",
+    "shareToSns": "SNS에 공유",
+    "fullscreen": "전체 화면",
+    "exitFullscreen": "전체 화면 종료",
+    "touch": "오아시스 소개"
+  },
+  "share": {
+    "facebook": "페이스북",
+    "twitter": "트위터",
+    "googlePlus": "구글 플러스",
+    "pinterest": "핀터레스트",
+    "tumblr": "텀블러"
+  },
+  "injection": {
+    "button": "주사 시뮬레이션 시작",
+    "injecting": "주사 중...",
+    "depth": "mm",
+    "checkmark": "✓"
+  },
+  "knife": {
+    "dropAgain": "다시 떨어뜨리기",
+    "successMessage": "✓ 칼이 안전하게 뒷면으로 떨어졌습니다!",
+    "successDescription": "칼이 항상 끝이 뾰족한 쪽으로 떨어지지 않는다는 것을 보여줍니다. 평평한 표면이 안정성을 제공합니다.",
+    "text": "칼을 떨어뜨려 어떻게 떨어지는지 확인하세요"
+  },
+  "screensaver": {
+    "forMac": "매킨토시용",
+    "forWin": "윈도우용",
+    "flashRequired": "이 화면 보호기를 설치하려면 Adobe Flash Player 10.1 이상이 필요합니다.",
+    "getFlash": "Adobe Flash Player"
+  },
+  "common": {
+    "loading": "로딩 중...",
+    "close": "닫기"
+  }
+}


### PR DESCRIPTION
Implemented comprehensive i18n (internationalization) system to support 2 languages: English (EN) and Korean (한국어).

Features:
- Language switcher UI in top-right corner
- Automatic language detection and persistence via localStorage
- Support for both HTML and JavaScript content translation
- Custom events for language change detection
- Responsive design for mobile and desktop

New files:
- i18n.js: Core internationalization library
- i18n-styles.css: Language switcher styling
- translations/en.json: English translations
- translations/ko.json: Korean translations
- I18N_USAGE_GUIDE.md: Complete API reference and usage guide
- MULTI_LANGUAGE_SETUP.md: Implementation overview and next steps
- example-i18n-usage.js: Code examples for updating JavaScript

Modified files:
- index.html: Added language switcher, i18n attributes, and library inclusion

How it works:
1. HTML elements use data-i18n attributes for automatic translation
2. JavaScript uses i18n.t() method to get translated strings
3. Users can switch languages via buttons (persists in localStorage)
4. Dynamic content can be translated by calling i18n.translatePage()

Next steps:
- Update minify/minify.js to use i18n.t() for dynamic content
- Add additional translations to JSON files as needed
- Test language switching across all interactive experiences