### PR TITLE
Reduce thunder class image carousel delay from 5s to 2s

### DIFF
--- a/minify/minify.js
+++ b/minify/minify.js
@@ -607,7 +607,7 @@ var thunderClass = thunderClass || function() {
     }
 
     function startCarousel() {
-        intervalId = setInterval(changeImage, 5000);
+        intervalId = setInterval(changeImage, 2000);
     }
 
     function stopCarousel() {


### PR DESCRIPTION
Changed the setInterval delay in startCarousel() from 5000ms to 2000ms for faster photo slide transitions.