### PR TITLE
Add welcome screen with language selection

### DIFF
--- a/i18n/translations.js
+++ b/i18n/translations.js
@@ -101,6 +101,20 @@ const translations = {
             ko: "한국어"
         },
 
+        // Welcome screen
+        welcome: {
+            title: "Welcome to Oasis",
+            subtitle: "Interactive experiences for phobia awareness",
+            description: "Explore calming, interactive experiences designed to help you understand and manage common phobias through gentle exposure.",
+            tileLabel: "Sample Experience",
+            tileDescription: "Click on posters like this to start an experience",
+            screenshotLabel: "What you'll experience",
+            screenshotDescription: "Each poster opens a unique interactive journey",
+            chooseLanguage: "Choose your language",
+            enterButton: "Enter Oasis",
+            clickAnywhere: "Click anywhere to continue"
+        },
+
         // Poster tiles (main page)
         posters: {
             plane: { title: "Plane", date: "Fear of Airplanes" },
@@ -218,6 +232,20 @@ const translations = {
         langSwitch: {
             en: "EN",
             ko: "한국어"
+        },
+
+        // Welcome screen
+        welcome: {
+            title: "오아시스에 오신 것을 환영합니다",
+            subtitle: "공포증 인식을 위한 인터랙티브 경험",
+            description: "부드러운 노출을 통해 일반적인 공포증을 이해하고 관리하는 데 도움이 되도록 설계된 차분한 인터랙티브 경험을 탐험하세요.",
+            tileLabel: "샘플 경험",
+            tileDescription: "이와 같은 포스터를 클릭하여 경험을 시작하세요",
+            screenshotLabel: "경험하게 될 것",
+            screenshotDescription: "각 포스터는 고유한 인터랙티브 여정을 엽니다",
+            chooseLanguage: "언어를 선택하세요",
+            enterButton: "오아시스 입장",
+            clickAnywhere: "계속하려면 아무 곳이나 클릭하세요"
         },
 
         // Poster tiles (main page)

--- a/index.html
+++ b/index.html
@@ -82,6 +82,352 @@
 </head>
 
 <body>
+    <!-- Welcome Screen -->
+    <div id="welcome-screen">
+        <div class="welcome-container">
+            <!-- Language Selection -->
+            <div class="welcome-language">
+                <span class="welcome-lang-label" data-i18n="welcome.chooseLanguage">Choose your language</span>
+                <div class="welcome-lang-buttons">
+                    <button class="welcome-lang-btn" data-lang="en">English</button>
+                    <button class="welcome-lang-btn" data-lang="ko">한국어</button>
+                </div>
+            </div>
+
+            <!-- Welcome Message -->
+            <div class="welcome-header">
+                <h1 class="welcome-title" data-i18n="welcome.title">Welcome to Oasis</h1>
+                <p class="welcome-subtitle" data-i18n="welcome.subtitle">Interactive experiences for phobia awareness</p>
+                <p class="welcome-description" data-i18n="welcome.description">Explore calming, interactive experiences designed to help you understand and manage common phobias through gentle exposure.</p>
+            </div>
+
+            <!-- Content Preview -->
+            <div class="welcome-preview">
+                <!-- Tile Preview -->
+                <div class="welcome-preview-item">
+                    <div class="welcome-tile-container">
+                        <img src="data/poster/injection_c.png" alt="Sample Poster Tile" class="welcome-tile-image">
+                    </div>
+                    <div class="welcome-preview-text">
+                        <span class="welcome-preview-label" data-i18n="welcome.tileLabel">Sample Experience</span>
+                        <span class="welcome-preview-desc" data-i18n="welcome.tileDescription">Click on posters like this to start an experience</span>
+                    </div>
+                </div>
+
+                <!-- Screenshot Preview -->
+                <div class="welcome-preview-item">
+                    <div class="welcome-screenshot-container">
+                        <img src="data/poster/injectionhd_c.png" alt="Experience Screenshot" class="welcome-screenshot-image">
+                    </div>
+                    <div class="welcome-preview-text">
+                        <span class="welcome-preview-label" data-i18n="welcome.screenshotLabel">What you'll experience</span>
+                        <span class="welcome-preview-desc" data-i18n="welcome.screenshotDescription">Each poster opens a unique interactive journey</span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Enter Button -->
+            <button class="welcome-enter-btn" data-i18n="welcome.enterButton">Enter Oasis</button>
+        </div>
+    </div>
+
+    <style>
+        /* Welcome Screen Styles */
+        #welcome-screen {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%);
+            z-index: 99999;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            opacity: 1;
+            transition: opacity 0.5s ease-out;
+        }
+
+        #welcome-screen.hidden {
+            opacity: 0;
+            pointer-events: none;
+        }
+
+        .welcome-container {
+            text-align: center;
+            max-width: 800px;
+            padding: 40px;
+            animation: fadeInUp 0.8s ease-out;
+        }
+
+        @keyframes fadeInUp {
+            from {
+                opacity: 0;
+                transform: translateY(30px);
+            }
+            to {
+                opacity: 1;
+                transform: translateY(0);
+            }
+        }
+
+        /* Language Selection */
+        .welcome-language {
+            margin-bottom: 30px;
+        }
+
+        .welcome-lang-label {
+            display: block;
+            color: rgba(255, 255, 255, 0.7);
+            font-size: 14px;
+            margin-bottom: 12px;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        }
+
+        .welcome-lang-buttons {
+            display: flex;
+            justify-content: center;
+            gap: 12px;
+        }
+
+        .welcome-lang-btn {
+            background: rgba(255, 255, 255, 0.1);
+            border: 2px solid rgba(255, 255, 255, 0.3);
+            color: #fff;
+            padding: 10px 24px;
+            border-radius: 25px;
+            font-size: 16px;
+            cursor: pointer;
+            transition: all 0.3s ease;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        }
+
+        .welcome-lang-btn:hover {
+            background: rgba(255, 255, 255, 0.2);
+            border-color: rgba(255, 255, 255, 0.5);
+        }
+
+        .welcome-lang-btn.active {
+            background: rgba(255, 255, 255, 0.95);
+            color: #1a1a2e;
+            border-color: #fff;
+        }
+
+        /* Welcome Header */
+        .welcome-header {
+            margin-bottom: 40px;
+        }
+
+        .welcome-title {
+            font-family: 'Crimson Text', Georgia, serif;
+            font-size: 48px;
+            color: #fff;
+            margin: 0 0 10px 0;
+            letter-spacing: 3px;
+            font-weight: 600;
+        }
+
+        .welcome-subtitle {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            font-size: 18px;
+            color: rgba(255, 255, 255, 0.8);
+            margin: 0 0 20px 0;
+            font-weight: 300;
+        }
+
+        .welcome-description {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            font-size: 15px;
+            color: rgba(255, 255, 255, 0.6);
+            margin: 0;
+            line-height: 1.6;
+            max-width: 600px;
+            margin: 0 auto;
+        }
+
+        /* Preview Section */
+        .welcome-preview {
+            display: flex;
+            justify-content: center;
+            gap: 40px;
+            margin-bottom: 40px;
+            flex-wrap: wrap;
+        }
+
+        .welcome-preview-item {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 15px;
+        }
+
+        .welcome-tile-container,
+        .welcome-screenshot-container {
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 12px;
+            padding: 10px;
+            box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
+        }
+
+        .welcome-tile-container:hover,
+        .welcome-screenshot-container:hover {
+            transform: translateY(-5px);
+            box-shadow: 0 15px 50px rgba(0, 0, 0, 0.4);
+        }
+
+        .welcome-tile-image {
+            width: 150px;
+            height: auto;
+            border-radius: 8px;
+            display: block;
+        }
+
+        .welcome-screenshot-image {
+            width: 200px;
+            height: auto;
+            border-radius: 8px;
+            display: block;
+        }
+
+        .welcome-preview-text {
+            text-align: center;
+        }
+
+        .welcome-preview-label {
+            display: block;
+            color: #fff;
+            font-size: 16px;
+            font-weight: 600;
+            margin-bottom: 5px;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        }
+
+        .welcome-preview-desc {
+            display: block;
+            color: rgba(255, 255, 255, 0.6);
+            font-size: 13px;
+            max-width: 180px;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        }
+
+        /* Enter Button */
+        .welcome-enter-btn {
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            border: none;
+            color: #fff;
+            padding: 16px 48px;
+            font-size: 18px;
+            border-radius: 30px;
+            cursor: pointer;
+            transition: all 0.3s ease;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            font-weight: 600;
+            letter-spacing: 1px;
+            box-shadow: 0 5px 20px rgba(102, 126, 234, 0.4);
+        }
+
+        .welcome-enter-btn:hover {
+            transform: translateY(-3px);
+            box-shadow: 0 8px 30px rgba(102, 126, 234, 0.6);
+        }
+
+        .welcome-enter-btn:active {
+            transform: translateY(-1px);
+        }
+
+        /* Mobile Responsive */
+        @media (max-width: 600px) {
+            .welcome-container {
+                padding: 20px;
+            }
+
+            .welcome-title {
+                font-size: 32px;
+            }
+
+            .welcome-subtitle {
+                font-size: 16px;
+            }
+
+            .welcome-description {
+                font-size: 14px;
+            }
+
+            .welcome-preview {
+                gap: 25px;
+            }
+
+            .welcome-tile-image {
+                width: 120px;
+            }
+
+            .welcome-screenshot-image {
+                width: 160px;
+            }
+
+            .welcome-enter-btn {
+                padding: 14px 36px;
+                font-size: 16px;
+            }
+        }
+    </style>
+
+    <script>
+        // Welcome Screen Logic
+        (function() {
+            document.addEventListener('DOMContentLoaded', function() {
+                const welcomeScreen = document.getElementById('welcome-screen');
+                const langBtns = document.querySelectorAll('.welcome-lang-btn');
+                const enterBtn = document.querySelector('.welcome-enter-btn');
+
+                // Check if user has already seen welcome screen
+                const hasSeenWelcome = sessionStorage.getItem('oasis-welcome-seen');
+                if (hasSeenWelcome) {
+                    welcomeScreen.style.display = 'none';
+                    return;
+                }
+
+                // Set initial active language button
+                function updateActiveLanguageBtn() {
+                    const currentLang = window.i18n ? window.i18n.getLanguage() : 'en';
+                    langBtns.forEach(btn => {
+                        if (btn.getAttribute('data-lang') === currentLang) {
+                            btn.classList.add('active');
+                        } else {
+                            btn.classList.remove('active');
+                        }
+                    });
+                }
+
+                // Initialize language buttons
+                setTimeout(updateActiveLanguageBtn, 100);
+
+                // Language button click handlers
+                langBtns.forEach(btn => {
+                    btn.addEventListener('click', function() {
+                        const lang = this.getAttribute('data-lang');
+                        if (window.i18n) {
+                            window.i18n.setLanguage(lang);
+                        }
+                        updateActiveLanguageBtn();
+                    });
+                });
+
+                // Enter button click handler
+                enterBtn.addEventListener('click', function() {
+                    welcomeScreen.classList.add('hidden');
+                    sessionStorage.setItem('oasis-welcome-seen', 'true');
+
+                    // Remove welcome screen from DOM after animation
+                    setTimeout(function() {
+                        welcomeScreen.style.display = 'none';
+                    }, 500);
+                });
+            });
+        })();
+    </script>
+
     <div id="preloader"></div>
     <div id="block"></div>
 


### PR DESCRIPTION
- Add bilingual (EN/KO) welcome screen that displays on first visit
- Feature language selection buttons at the top
- Include sample tile preview and experience screenshot
- Add smooth fade-out animation when entering the app
- Store session state to skip welcome on return visits