### PR TITLE
Improve Three.js loading with polling mechanism

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,7 +152,7 @@ body {
     <!-- Three.js for 3D game -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r152/three.min.js"></script>
 
-    <script src="minify/minify.js?id=4"></script>
+    <script src="minify/minify.js?id=5"></script>
 
 <script>
 // Preload critical images immediately - don't wait for window.load

--- a/minify/minify.js
+++ b/minify/minify.js
@@ -4357,23 +4357,25 @@ var editorMode=false,editorObjects=[],editorSelected=null,editorHighlighted=null
 var time=0;
 
 function loadThreeJS(callback){
-    if(window.THREE){
-        THREE=window.THREE;
-        callback();
-        return;
+    var attempts=0;
+    var maxAttempts=20;
+    function checkThree(){
+        if(window.THREE){
+            THREE=window.THREE;
+            console.log('Three.js loaded successfully');
+            callback();
+            return;
+        }
+        attempts++;
+        if(attempts<maxAttempts){
+            setTimeout(checkThree,100);
+        }else{
+            console.error('Three.js not available after waiting');
+            var errDiv=document.getElementById('darkness-canvas-container');
+            if(errDiv)errDiv.innerHTML='<div style="color:#ff6666;padding:40px;text-align:center;font-size:16px;">Three.js library not available.<br>Please refresh the page.</div>';
+        }
     }
-    var script=document.createElement('script');
-    script.src='https://cdnjs.cloudflare.com/ajax/libs/three.js/r152/three.min.js';
-    script.onload=function(){
-        THREE=window.THREE;
-        callback();
-    };
-    script.onerror=function(){
-        console.error('Failed to load Three.js');
-        var errDiv=document.getElementById('darkness-canvas-container');
-        if(errDiv)errDiv.innerHTML='<div style="color:#ff6666;padding:40px;text-align:center;font-size:16px;">Failed to load Three.js library.</div>';
-    };
-    document.head.appendChild(script);
+    checkThree();
 }
 
 function init(parentElement){


### PR DESCRIPTION
Instead of trying to dynamically load Three.js, use a polling approach that waits for window.THREE to become available (up to 2 seconds with 20 attempts at 100ms intervals). This handles the case where the CDN script is still loading when the tile is clicked.