### PR TITLE
Fix Three.js version - CapsuleGeometry requires r133+

### DIFF
--- a/minify/injectionscene.html
+++ b/minify/injectionscene.html
@@ -90,7 +90,7 @@
         <div class="description">Standard medical needle</div>
     </div>
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.152.0/build/three.min.js"></script>
     <script>
         // Scene setup
         const container = document.getElementById('container');


### PR DESCRIPTION
Update Three.js from r128 to r152 which includes CapsuleGeometry that is used for finger segments in the arm model.

https://claude.ai/code/session_01Y2zn2kpR3pfpWtV9g3737W