### PR TITLE
Fix scene offset bug causing arm and syringes to disappear

### DIFF
--- a/minify/injectionscene.html
+++ b/minify/injectionscene.html
@@ -122,7 +122,9 @@
         mainLight.position.set(2, 8, 4);
         mainLight.castShadow = true;
         scene.add(mainLight);
-        scene.add(new THREE.DirectionalLight(0x88aacc, 0.4)).position.set(-3, 4, 2);
+        const fillLight = new THREE.DirectionalLight(0x88aacc, 0.4);
+        fillLight.position.set(-3, 4, 2);
+        scene.add(fillLight);
 
         // Materials
         const skinMaterial = new THREE.MeshStandardMaterial({


### PR DESCRIPTION
scene.add() returns the scene, not the added object. Calling .position.set() on it was offsetting the entire scene position, moving everything out of view.

https://claude.ai/code/session_01Y2zn2kpR3pfpWtV9g3737W