### PR TITLE
Add Korean i18n support for diagnostic tests

### DIFF
--- a/i18n/translations.js
+++ b/i18n/translations.js
@@ -101,6 +101,93 @@ const translations = {
             ko: "한국어"
         },
 
+        // Diagnostic assessments
+        diagnostic: {
+            continueToExperience: "Continue to Experience",
+
+            // Airplane diagnostic
+            airplane: {
+                title: "Fear of Flying Assessment",
+                q1: "Do you feel anxious when thinking about flying?",
+                q2: "Have you avoided flying due to fear?",
+                q3: "Do you experience physical symptoms (sweating, racing heart) related to flying?",
+                q4: "How would you rate your fear of flying?",
+                q5: "Does turbulence cause you significant distress?",
+                q6: "Do thoughts of plane crashes intrude on your daily life?",
+                options: {
+                    never: "Never",
+                    sometimes: "Sometimes",
+                    often: "Often",
+                    always: "Always",
+                    onceOrTwice: "Once or twice",
+                    severalTimes: "Several times",
+                    alwaysAvoid: "Always avoid",
+                    noSymptoms: "No symptoms",
+                    mild: "Mild",
+                    moderate: "Moderate",
+                    severe: "Severe",
+                    noFear: "No fear",
+                    notAtAll: "Not at all",
+                    aLittle: "A little",
+                    quiteBit: "Quite a bit",
+                    extremely: "Extremely",
+                    rarely: "Rarely",
+                    frequently: "Frequently"
+                }
+            },
+
+            // Injection diagnostic
+            injection: {
+                title: "Fear of Needles Assessment",
+                q1: "Do you feel anxious when thinking about needles or injections?",
+                q2: "Have you avoided medical procedures due to fear of needles?",
+                q3: "Do you experience physical symptoms (sweating, dizziness) around needles?",
+                q4: "How would you rate your fear of injections?",
+                q5: "Do you feel faint or nauseous when seeing needles?",
+                q6: "Does anticipating an injection cause you significant distress?"
+            },
+
+            // Thunder diagnostic
+            thunder: {
+                title: "Fear of Thunder Assessment",
+                q1: "Do you feel anxious during thunderstorms?",
+                q2: "Have you sought shelter or hidden during storms due to fear?",
+                q3: "Do you experience physical symptoms (trembling, rapid heartbeat) during thunder?",
+                q4: "How would you rate your fear of thunder and lightning?",
+                q5: "Do you check weather forecasts obsessively to avoid storms?",
+                q6: "Does the sound of thunder cause you significant distress?",
+                options: {
+                    occasionally: "Occasionally",
+                    constantly: "Constantly"
+                }
+            },
+
+            // Darkness diagnostic
+            darkness: {
+                title: "Fear of Darkness Assessment",
+                q1: "Do you feel anxious in dark environments?",
+                q2: "Have you avoided dark places due to fear?",
+                q3: "Do you need a light source to fall asleep?",
+                q4: "How would you rate your fear of darkness?",
+                q5: "Do you imagine threatening things in the dark?",
+                q6: "Does entering a dark room cause immediate anxiety?",
+                options: {
+                    usually: "Usually"
+                }
+            },
+
+            // Heights diagnostic
+            heights: {
+                title: "Fear of Heights Assessment",
+                q1: "Do you feel anxious when at high places?",
+                q2: "Have you avoided tall buildings, bridges, or balconies due to fear?",
+                q3: "Do you experience physical symptoms (dizziness, weak knees) at heights?",
+                q4: "How would you rate your fear of heights?",
+                q5: "Do you feel an urge to jump or fear of falling when at heights?",
+                q6: "Does looking down from a height cause immediate panic?"
+            }
+        },
+
         // Poster tiles (main page)
         posters: {
             plane: { title: "Plane", date: "Fear of Airplanes" },
@@ -218,6 +305,93 @@ const translations = {
         langSwitch: {
             en: "EN",
             ko: "한국어"
+        },
+
+        // Diagnostic assessments
+        diagnostic: {
+            continueToExperience: "체험 계속하기",
+
+            // Airplane diagnostic
+            airplane: {
+                title: "비행 공포증 평가",
+                q1: "비행에 대해 생각할 때 불안함을 느끼시나요?",
+                q2: "두려움 때문에 비행을 피한 적이 있나요?",
+                q3: "비행과 관련하여 신체적 증상(땀, 심장 두근거림)을 경험하시나요?",
+                q4: "비행에 대한 두려움을 어떻게 평가하시나요?",
+                q5: "난기류가 심각한 고통을 유발하나요?",
+                q6: "비행기 추락에 대한 생각이 일상생활에 침투하나요?",
+                options: {
+                    never: "전혀 없음",
+                    sometimes: "가끔",
+                    often: "자주",
+                    always: "항상",
+                    onceOrTwice: "한두 번",
+                    severalTimes: "여러 번",
+                    alwaysAvoid: "항상 피함",
+                    noSymptoms: "증상 없음",
+                    mild: "가벼움",
+                    moderate: "보통",
+                    severe: "심함",
+                    noFear: "두려움 없음",
+                    notAtAll: "전혀 아님",
+                    aLittle: "조금",
+                    quiteBit: "꽤 많이",
+                    extremely: "매우 심하게",
+                    rarely: "드물게",
+                    frequently: "자주"
+                }
+            },
+
+            // Injection diagnostic
+            injection: {
+                title: "주사 공포증 평가",
+                q1: "바늘이나 주사에 대해 생각할 때 불안함을 느끼시나요?",
+                q2: "바늘에 대한 두려움 때문에 의료 시술을 피한 적이 있나요?",
+                q3: "바늘 주변에서 신체적 증상(땀, 어지러움)을 경험하시나요?",
+                q4: "주사에 대한 두려움을 어떻게 평가하시나요?",
+                q5: "바늘을 볼 때 기절하거나 메스꺼움을 느끼시나요?",
+                q6: "주사를 예상할 때 심각한 고통을 느끼시나요?"
+            },
+
+            // Thunder diagnostic
+            thunder: {
+                title: "천둥 공포증 평가",
+                q1: "천둥번개가 치는 동안 불안함을 느끼시나요?",
+                q2: "두려움 때문에 폭풍 중에 피난처를 찾거나 숨은 적이 있나요?",
+                q3: "천둥 중에 신체적 증상(떨림, 빠른 심장박동)을 경험하시나요?",
+                q4: "천둥과 번개에 대한 두려움을 어떻게 평가하시나요?",
+                q5: "폭풍을 피하기 위해 날씨 예보를 집착적으로 확인하시나요?",
+                q6: "천둥 소리가 심각한 고통을 유발하나요?",
+                options: {
+                    occasionally: "가끔",
+                    constantly: "끊임없이"
+                }
+            },
+
+            // Darkness diagnostic
+            darkness: {
+                title: "어둠 공포증 평가",
+                q1: "어두운 환경에서 불안함을 느끼시나요?",
+                q2: "두려움 때문에 어두운 곳을 피한 적이 있나요?",
+                q3: "잠들기 위해 조명이 필요하신가요?",
+                q4: "어둠에 대한 두려움을 어떻게 평가하시나요?",
+                q5: "어둠 속에서 위협적인 것을 상상하시나요?",
+                q6: "어두운 방에 들어가면 즉각적인 불안을 느끼시나요?",
+                options: {
+                    usually: "보통"
+                }
+            },
+
+            // Heights diagnostic
+            heights: {
+                title: "고소 공포증 평가",
+                q1: "높은 곳에 있을 때 불안함을 느끼시나요?",
+                q2: "두려움 때문에 높은 건물, 다리, 발코니를 피한 적이 있나요?",
+                q3: "높은 곳에서 신체적 증상(어지러움, 무릎 힘 빠짐)을 경험하시나요?",
+                q4: "높은 곳에 대한 두려움을 어떻게 평가하시나요?",
+                q5: "높은 곳에서 뛰어내리고 싶은 충동이나 떨어질 것 같은 두려움을 느끼시나요?",
+                q6: "높은 곳에서 아래를 내려다보면 즉각적인 공황을 느끼시나요?"
+            }
         },
 
         // Poster tiles (main page)

--- a/minify/minify.js
+++ b/minify/minify.js
@@ -115,16 +115,25 @@ var airplaneDiagnostic = airplaneDiagnostic || function() {
     var animationFrameId = null;
     var clouds = [];
     var planeEl = null;
-    var questions = [
-        { q: "Do you feel anxious when thinking about flying?", options: ["Never", "Sometimes", "Often", "Always"] },
-        { q: "Have you avoided flying due to fear?", options: ["Never", "Once or twice", "Several times", "Always avoid"] },
-        { q: "Do you experience physical symptoms (sweating, racing heart) related to flying?", options: ["No symptoms", "Mild", "Moderate", "Severe"] },
-        { q: "How would you rate your fear of flying?", options: ["No fear", "Mild", "Moderate", "Severe"] },
-        { q: "Does turbulence cause you significant distress?", options: ["Not at all", "A little", "Quite a bit", "Extremely"] },
-        { q: "Do thoughts of plane crashes intrude on your daily life?", options: ["Never", "Rarely", "Sometimes", "Frequently"] }
-    ];
     var answers = [];
     var bgColor = "#2691c9";
+
+    function getTranslations() {
+        var t = window.i18n ? window.i18n.t : function(k) { return k; };
+        var o = function(key) { return t('diagnostic.airplane.options.' + key); };
+        return {
+            title: t('diagnostic.airplane.title'),
+            continueBtn: t('diagnostic.continueToExperience'),
+            questions: [
+                { q: t('diagnostic.airplane.q1'), options: [o('never'), o('sometimes'), o('often'), o('always')] },
+                { q: t('diagnostic.airplane.q2'), options: [o('never'), o('onceOrTwice'), o('severalTimes'), o('alwaysAvoid')] },
+                { q: t('diagnostic.airplane.q3'), options: [o('noSymptoms'), o('mild'), o('moderate'), o('severe')] },
+                { q: t('diagnostic.airplane.q4'), options: [o('noFear'), o('mild'), o('moderate'), o('severe')] },
+                { q: t('diagnostic.airplane.q5'), options: [o('notAtAll'), o('aLittle'), o('quiteBit'), o('extremely')] },
+                { q: t('diagnostic.airplane.q6'), options: [o('never'), o('rarely'), o('sometimes'), o('frequently')] }
+            ]
+        };
+    }
 
     function addStyles() {
         if (!document.getElementById('airplane-diagnostic-styles')) {
@@ -287,7 +296,9 @@ var airplaneDiagnostic = airplaneDiagnostic || function() {
     }
 
     function buildQuestionsHTML() {
-        var html = '<div class="diagnostic-title">Fear of Flying Assessment</div>';
+        var trans = getTranslations();
+        var questions = trans.questions;
+        var html = '<div class="diagnostic-title">' + trans.title + '</div>';
         for (var i = 0; i < questions.length; i++) {
             html += '<div class="diagnostic-question" data-index="' + i + '">';
             html += '<div class="diagnostic-question-text">' + (i + 1) + '. ' + questions[i].q + '</div>';
@@ -391,7 +402,7 @@ var airplaneDiagnostic = airplaneDiagnostic || function() {
 
     function checkAllAnswered() {
         var allAnswered = true;
-        for (var i = 0; i < questions.length; i++) {
+        for (var i = 0; i < 6; i++) {
             if (answers[i] === undefined) {
                 allAnswered = false;
                 break;
@@ -439,13 +450,14 @@ var airplaneDiagnostic = airplaneDiagnostic || function() {
             answers = [];
             planeX = -100;
             planeY = 25;
+            var trans = getTranslations();
 
             container.innerHTML = '\
                 <div class="diagnostic-container" id="diagnostic-screen">\
                     <div class="diagnostic-bg-layer"></div>\
                     <div class="diagnostic-questions-panel" id="questions-panel">\
                         ' + buildQuestionsHTML() + '\
-                        <button class="diagnostic-continue" id="diagnostic-continue">Continue to Experience</button>\
+                        <button class="diagnostic-continue" id="diagnostic-continue">' + trans.continueBtn + '</button>\
                     </div>\
                 </div>\
                 <div class="diagnostic-main-content" id="diagnostic-main-content"></div>\
@@ -520,19 +532,28 @@ var airplaneDiagnostic = airplaneDiagnostic || function() {
 var injectionDiagnostic = injectionDiagnostic || function() {
     var container;
     var diagnosticScreen, mainContent, questionsPanel;
-    var questions = [
-        { q: "Do you feel anxious when thinking about needles or injections?", options: ["Never", "Sometimes", "Often", "Always"] },
-        { q: "Have you avoided medical procedures due to fear of needles?", options: ["Never", "Once or twice", "Several times", "Always avoid"] },
-        { q: "Do you experience physical symptoms (sweating, dizziness) around needles?", options: ["No symptoms", "Mild", "Moderate", "Severe"] },
-        { q: "How would you rate your fear of injections?", options: ["No fear", "Mild", "Moderate", "Severe"] },
-        { q: "Do you feel faint or nauseous when seeing needles?", options: ["Not at all", "A little", "Quite a bit", "Extremely"] },
-        { q: "Does anticipating an injection cause you significant distress?", options: ["Never", "Rarely", "Sometimes", "Frequently"] }
-    ];
     var answers = [];
     var bgColor = "#1a1a2e";
     var particles = [];
     var animationFrameId = null;
     var canvas, ctx;
+
+    function getTranslations() {
+        var t = window.i18n ? window.i18n.t : function(k) { return k; };
+        var o = function(key) { return t('diagnostic.airplane.options.' + key); };
+        return {
+            title: t('diagnostic.injection.title'),
+            continueBtn: t('diagnostic.continueToExperience'),
+            questions: [
+                { q: t('diagnostic.injection.q1'), options: [o('never'), o('sometimes'), o('often'), o('always')] },
+                { q: t('diagnostic.injection.q2'), options: [o('never'), o('onceOrTwice'), o('severalTimes'), o('alwaysAvoid')] },
+                { q: t('diagnostic.injection.q3'), options: [o('noSymptoms'), o('mild'), o('moderate'), o('severe')] },
+                { q: t('diagnostic.injection.q4'), options: [o('noFear'), o('mild'), o('moderate'), o('severe')] },
+                { q: t('diagnostic.injection.q5'), options: [o('notAtAll'), o('aLittle'), o('quiteBit'), o('extremely')] },
+                { q: t('diagnostic.injection.q6'), options: [o('never'), o('rarely'), o('sometimes'), o('frequently')] }
+            ]
+        };
+    }
 
     function addStyles() {
         if (!document.getElementById('injection-diagnostic-styles')) {
@@ -653,7 +674,9 @@ var injectionDiagnostic = injectionDiagnostic || function() {
     }
 
     function buildQuestionsHTML() {
-        var html = '<div class="inj-diag-title">Fear of Needles Assessment</div>';
+        var trans = getTranslations();
+        var questions = trans.questions;
+        var html = '<div class="inj-diag-title">' + trans.title + '</div>';
         for (var i = 0; i < questions.length; i++) {
             html += '<div class="inj-diag-question" data-index="' + i + '">';
             html += '<div class="inj-diag-question-text">' + (i + 1) + '. ' + questions[i].q + '</div>';
@@ -717,7 +740,7 @@ var injectionDiagnostic = injectionDiagnostic || function() {
 
     function checkAllAnswered() {
         var allAnswered = true;
-        for (var i = 0; i < questions.length; i++) {
+        for (var i = 0; i < 6; i++) {
             if (answers[i] === undefined) { allAnswered = false; break; }
         }
         var btn = container.querySelector('.inj-diag-continue');
@@ -747,12 +770,13 @@ var injectionDiagnostic = injectionDiagnostic || function() {
             container = parentElement;
             addStyles();
             answers = [];
+            var trans = getTranslations();
             container.innerHTML = '\
                 <div class="inj-diag-container" id="inj-diag-screen">\
                     <canvas class="inj-diag-canvas"></canvas>\
                     <div class="inj-diag-panel" id="inj-diag-panel">\
                         ' + buildQuestionsHTML() + '\
-                        <button class="inj-diag-continue">Continue to Experience</button>\
+                        <button class="inj-diag-continue">' + trans.continueBtn + '</button>\
                     </div>\
                 </div>\
                 <div class="inj-diag-main" id="inj-diag-main"></div>\
@@ -796,19 +820,29 @@ var injectionDiagnostic = injectionDiagnostic || function() {
 var thunderDiagnostic = thunderDiagnostic || function() {
     var container;
     var diagnosticScreen, mainContent, questionsPanel;
-    var questions = [
-        { q: "Do you feel anxious during thunderstorms?", options: ["Never", "Sometimes", "Often", "Always"] },
-        { q: "Have you sought shelter or hidden during storms due to fear?", options: ["Never", "Once or twice", "Several times", "Always"] },
-        { q: "Do you experience physical symptoms (trembling, rapid heartbeat) during thunder?", options: ["No symptoms", "Mild", "Moderate", "Severe"] },
-        { q: "How would you rate your fear of thunder and lightning?", options: ["No fear", "Mild", "Moderate", "Severe"] },
-        { q: "Do you check weather forecasts obsessively to avoid storms?", options: ["Not at all", "Occasionally", "Often", "Constantly"] },
-        { q: "Does the sound of thunder cause you significant distress?", options: ["Never", "Rarely", "Sometimes", "Frequently"] }
-    ];
     var answers = [];
     var bgColor = "#1a1a2e";
     var animationFrameId = null;
     var lightningTimeout = null;
     var flashEl = null;
+
+    function getTranslations() {
+        var t = window.i18n ? window.i18n.t : function(k) { return k; };
+        var o = function(key) { return t('diagnostic.airplane.options.' + key); };
+        var ot = function(key) { return t('diagnostic.thunder.options.' + key); };
+        return {
+            title: t('diagnostic.thunder.title'),
+            continueBtn: t('diagnostic.continueToExperience'),
+            questions: [
+                { q: t('diagnostic.thunder.q1'), options: [o('never'), o('sometimes'), o('often'), o('always')] },
+                { q: t('diagnostic.thunder.q2'), options: [o('never'), o('onceOrTwice'), o('severalTimes'), o('always')] },
+                { q: t('diagnostic.thunder.q3'), options: [o('noSymptoms'), o('mild'), o('moderate'), o('severe')] },
+                { q: t('diagnostic.thunder.q4'), options: [o('noFear'), o('mild'), o('moderate'), o('severe')] },
+                { q: t('diagnostic.thunder.q5'), options: [o('notAtAll'), ot('occasionally'), o('often'), ot('constantly')] },
+                { q: t('diagnostic.thunder.q6'), options: [o('never'), o('rarely'), o('sometimes'), o('frequently')] }
+            ]
+        };
+    }
 
     function addStyles() {
         if (!document.getElementById('thunder-diagnostic-styles')) {
@@ -902,7 +936,9 @@ var thunderDiagnostic = thunderDiagnostic || function() {
     }
 
     function buildQuestionsHTML() {
-        var html = '<div class="thunder-diag-title">Fear of Thunder Assessment</div>';
+        var trans = getTranslations();
+        var questions = trans.questions;
+        var html = '<div class="thunder-diag-title">' + trans.title + '</div>';
         for (var i = 0; i < questions.length; i++) {
             html += '<div class="thunder-diag-question" data-index="' + i + '">';
             html += '<div class="thunder-diag-question-text">' + (i + 1) + '. ' + questions[i].q + '</div>';
@@ -947,7 +983,7 @@ var thunderDiagnostic = thunderDiagnostic || function() {
 
     function checkAllAnswered() {
         var allAnswered = true;
-        for (var i = 0; i < questions.length; i++) {
+        for (var i = 0; i < 6; i++) {
             if (answers[i] === undefined) { allAnswered = false; break; }
         }
         var btn = container.querySelector('.thunder-diag-continue');
@@ -977,6 +1013,7 @@ var thunderDiagnostic = thunderDiagnostic || function() {
             container = parentElement;
             addStyles();
             answers = [];
+            var trans = getTranslations();
             container.innerHTML = '\
                 <div class="thunder-diag-container" id="thunder-diag-screen">\
                     <div class="thunder-diag-clouds"></div>\
@@ -984,7 +1021,7 @@ var thunderDiagnostic = thunderDiagnostic || function() {
                     <div class="thunder-diag-flash"></div>\
                     <div class="thunder-diag-panel" id="thunder-diag-panel">\
                         ' + buildQuestionsHTML() + '\
-                        <button class="thunder-diag-continue">Continue to Experience</button>\
+                        <button class="thunder-diag-continue">' + trans.continueBtn + '</button>\
                     </div>\
                 </div>\
                 <div class="thunder-diag-main" id="thunder-diag-main"></div>\
@@ -1027,18 +1064,29 @@ var thunderDiagnostic = thunderDiagnostic || function() {
 var darknessDiagnostic = darknessDiagnostic || function() {
     var container;
     var diagnosticScreen, mainContent, questionsPanel;
-    var questions = [
-        { q: "Do you feel anxious in dark environments?", options: ["Never", "Sometimes", "Often", "Always"] },
-        { q: "Have you avoided dark places due to fear?", options: ["Never", "Once or twice", "Several times", "Always avoid"] },
-        { q: "Do you need a light source to fall asleep?", options: ["Never", "Sometimes", "Usually", "Always"] },
-        { q: "How would you rate your fear of darkness?", options: ["No fear", "Mild", "Moderate", "Severe"] },
-        { q: "Do you imagine threatening things in the dark?", options: ["Not at all", "Occasionally", "Often", "Constantly"] },
-        { q: "Does entering a dark room cause immediate anxiety?", options: ["Never", "Rarely", "Sometimes", "Always"] }
-    ];
     var answers = [];
     var animationFrameId = null;
     var particles = [];
     var canvas, ctx;
+
+    function getTranslations() {
+        var t = window.i18n ? window.i18n.t : function(k) { return k; };
+        var o = function(key) { return t('diagnostic.airplane.options.' + key); };
+        var od = function(key) { return t('diagnostic.darkness.options.' + key); };
+        var ot = function(key) { return t('diagnostic.thunder.options.' + key); };
+        return {
+            title: t('diagnostic.darkness.title'),
+            continueBtn: t('diagnostic.continueToExperience'),
+            questions: [
+                { q: t('diagnostic.darkness.q1'), options: [o('never'), o('sometimes'), o('often'), o('always')] },
+                { q: t('diagnostic.darkness.q2'), options: [o('never'), o('onceOrTwice'), o('severalTimes'), o('alwaysAvoid')] },
+                { q: t('diagnostic.darkness.q3'), options: [o('never'), o('sometimes'), od('usually'), o('always')] },
+                { q: t('diagnostic.darkness.q4'), options: [o('noFear'), o('mild'), o('moderate'), o('severe')] },
+                { q: t('diagnostic.darkness.q5'), options: [o('notAtAll'), ot('occasionally'), o('often'), ot('constantly')] },
+                { q: t('diagnostic.darkness.q6'), options: [o('never'), o('rarely'), o('sometimes'), o('always')] }
+            ]
+        };
+    }
 
     function addStyles() {
         if (!document.getElementById('darkness-diagnostic-styles')) {
@@ -1119,7 +1167,9 @@ var darknessDiagnostic = darknessDiagnostic || function() {
     }
 
     function buildQuestionsHTML() {
-        var html = '<div class="dark-diag-title">Fear of Darkness Assessment</div>';
+        var trans = getTranslations();
+        var questions = trans.questions;
+        var html = '<div class="dark-diag-title">' + trans.title + '</div>';
         for (var i = 0; i < questions.length; i++) {
             html += '<div class="dark-diag-question" data-index="' + i + '">';
             html += '<div class="dark-diag-question-text">' + (i + 1) + '. ' + questions[i].q + '</div>';
@@ -1188,7 +1238,7 @@ var darknessDiagnostic = darknessDiagnostic || function() {
 
     function checkAllAnswered() {
         var allAnswered = true;
-        for (var i = 0; i < questions.length; i++) {
+        for (var i = 0; i < 6; i++) {
             if (answers[i] === undefined) { allAnswered = false; break; }
         }
         var btn = container.querySelector('.dark-diag-continue');
@@ -1218,13 +1268,14 @@ var darknessDiagnostic = darknessDiagnostic || function() {
             container = parentElement;
             addStyles();
             answers = [];
+            var trans = getTranslations();
             container.innerHTML = '\
                 <div class="dark-diag-container" id="dark-diag-screen">\
                     <canvas class="dark-diag-canvas"></canvas>\
                     <div class="dark-diag-vignette"></div>\
                     <div class="dark-diag-panel" id="dark-diag-panel">\
                         ' + buildQuestionsHTML() + '\
-                        <button class="dark-diag-continue">Continue to Experience</button>\
+                        <button class="dark-diag-continue">' + trans.continueBtn + '</button>\
                     </div>\
                 </div>\
                 <div class="dark-diag-main" id="dark-diag-main"></div>\
@@ -1268,19 +1319,29 @@ var darknessDiagnostic = darknessDiagnostic || function() {
 var heightsDiagnostic = heightsDiagnostic || function() {
     var container;
     var diagnosticScreen, mainContent, questionsPanel;
-    var questions = [
-        { q: "Do you feel anxious when at high places?", options: ["Never", "Sometimes", "Often", "Always"] },
-        { q: "Have you avoided tall buildings, bridges, or balconies due to fear?", options: ["Never", "Once or twice", "Several times", "Always avoid"] },
-        { q: "Do you experience physical symptoms (dizziness, weak knees) at heights?", options: ["No symptoms", "Mild", "Moderate", "Severe"] },
-        { q: "How would you rate your fear of heights?", options: ["No fear", "Mild", "Moderate", "Severe"] },
-        { q: "Do you feel an urge to jump or fear of falling when at heights?", options: ["Not at all", "Occasionally", "Often", "Constantly"] },
-        { q: "Does looking down from a height cause immediate panic?", options: ["Never", "Rarely", "Sometimes", "Always"] }
-    ];
     var answers = [];
     var animationFrameId = null;
     var clouds = [];
     var birds = [];
     var canvas, ctx;
+
+    function getTranslations() {
+        var t = window.i18n ? window.i18n.t : function(k) { return k; };
+        var o = function(key) { return t('diagnostic.airplane.options.' + key); };
+        var ot = function(key) { return t('diagnostic.thunder.options.' + key); };
+        return {
+            title: t('diagnostic.heights.title'),
+            continueBtn: t('diagnostic.continueToExperience'),
+            questions: [
+                { q: t('diagnostic.heights.q1'), options: [o('never'), o('sometimes'), o('often'), o('always')] },
+                { q: t('diagnostic.heights.q2'), options: [o('never'), o('onceOrTwice'), o('severalTimes'), o('alwaysAvoid')] },
+                { q: t('diagnostic.heights.q3'), options: [o('noSymptoms'), o('mild'), o('moderate'), o('severe')] },
+                { q: t('diagnostic.heights.q4'), options: [o('noFear'), o('mild'), o('moderate'), o('severe')] },
+                { q: t('diagnostic.heights.q5'), options: [o('notAtAll'), ot('occasionally'), o('often'), ot('constantly')] },
+                { q: t('diagnostic.heights.q6'), options: [o('never'), o('rarely'), o('sometimes'), o('always')] }
+            ]
+        };
+    }
 
     function addStyles() {
         if (!document.getElementById('heights-diagnostic-styles')) {
@@ -1361,7 +1422,9 @@ var heightsDiagnostic = heightsDiagnostic || function() {
     }
 
     function buildQuestionsHTML() {
-        var html = '<div class="heights-diag-title">Fear of Heights Assessment</div>';
+        var trans = getTranslations();
+        var questions = trans.questions;
+        var html = '<div class="heights-diag-title">' + trans.title + '</div>';
         for (var i = 0; i < questions.length; i++) {
             html += '<div class="heights-diag-question" data-index="' + i + '">';
             html += '<div class="heights-diag-question-text">' + (i + 1) + '. ' + questions[i].q + '</div>';
@@ -1466,7 +1529,7 @@ var heightsDiagnostic = heightsDiagnostic || function() {
 
     function checkAllAnswered() {
         var allAnswered = true;
-        for (var i = 0; i < questions.length; i++) {
+        for (var i = 0; i < 6; i++) {
             if (answers[i] === undefined) { allAnswered = false; break; }
         }
         var btn = container.querySelector('.heights-diag-continue');
@@ -1496,13 +1559,14 @@ var heightsDiagnostic = heightsDiagnostic || function() {
             container = parentElement;
             addStyles();
             answers = [];
+            var trans = getTranslations();
             container.innerHTML = '\
                 <div class="heights-diag-container" id="heights-diag-screen">\
                     <canvas class="heights-diag-canvas"></canvas>\
                     <div class="heights-diag-ground"></div>\
                     <div class="heights-diag-panel" id="heights-diag-panel">\
                         ' + buildQuestionsHTML() + '\
-                        <button class="heights-diag-continue">Continue to Experience</button>\
+                        <button class="heights-diag-continue">' + trans.continueBtn + '</button>\
                     </div>\
                 </div>\
                 <div class="heights-diag-main" id="heights-diag-main"></div>\


### PR DESCRIPTION
- Added English and Korean translations for all 5 diagnostic modules
- Airplane, Injection, Thunder, Darkness, Heights assessments
- Translated questions, options, titles, and continue button
- Each diagnostic module now uses getTranslations() for dynamic language

https://claude.ai/code/session_01Y2zn2kpR3pfpWtV9g3737W