### PR TITLE
Skip surveys for non-logged-in users

### DIFF
--- a/minify/minify.js
+++ b/minify/minify.js
@@ -487,8 +487,8 @@ var airplaneDiagnostic = airplaneDiagnostic || function() {
         },
 
         start: function() {
-            // Skip diagnostic if user has already completed one for this phobia
-            if (typeof OasisAccount !== 'undefined' && OasisAccount.hasDiagnostic('airplane')) {
+            // Skip diagnostic if user is not logged in or has already completed one for this phobia
+            if (typeof OasisAccount !== 'undefined' && (!OasisAccount.isLoggedIn() || OasisAccount.hasDiagnostic('airplane'))) {
                 diagnosticScreen.style.display = 'none';
                 mainContent.classList.add('visible');
                 airplane.init(mainContent);
@@ -823,8 +823,8 @@ var injectionDiagnostic = injectionDiagnostic || function() {
             initParticles();
         },
         start: function() {
-            // Skip diagnostic if user has already completed one for this phobia
-            if (typeof OasisAccount !== 'undefined' && OasisAccount.hasDiagnostic('injection')) {
+            // Skip diagnostic if user is not logged in or has already completed one for this phobia
+            if (typeof OasisAccount !== 'undefined' && (!OasisAccount.isLoggedIn() || OasisAccount.hasDiagnostic('injection'))) {
                 diagnosticScreen.style.display = 'none';
                 mainContent.classList.add('visible');
                 injection.init(mainContent);
@@ -1091,8 +1091,8 @@ var thunderDiagnostic = thunderDiagnostic || function() {
             flashEl = container.querySelector('.thunder-diag-flash');
         },
         start: function() {
-            // Skip diagnostic if user has already completed one for this phobia
-            if (typeof OasisAccount !== 'undefined' && OasisAccount.hasDiagnostic('thunder')) {
+            // Skip diagnostic if user is not logged in or has already completed one for this phobia
+            if (typeof OasisAccount !== 'undefined' && (!OasisAccount.isLoggedIn() || OasisAccount.hasDiagnostic('thunder'))) {
                 diagnosticScreen.style.display = 'none';
                 mainContent.classList.add('visible');
                 thunderClass.init(mainContent);
@@ -1369,8 +1369,8 @@ var darknessDiagnostic = darknessDiagnostic || function() {
             initParticles();
         },
         start: function() {
-            // Skip diagnostic if user has already completed one for this phobia
-            if (typeof OasisAccount !== 'undefined' && OasisAccount.hasDiagnostic('darkness')) {
+            // Skip diagnostic if user is not logged in or has already completed one for this phobia
+            if (typeof OasisAccount !== 'undefined' && (!OasisAccount.isLoggedIn() || OasisAccount.hasDiagnostic('darkness'))) {
                 diagnosticScreen.style.display = 'none';
                 mainContent.classList.add('visible');
                 Darkness.init(mainContent);
@@ -1683,8 +1683,8 @@ var heightsDiagnostic = heightsDiagnostic || function() {
             initAnimation();
         },
         start: function() {
-            // Skip diagnostic if user has already completed one for this phobia
-            if (typeof OasisAccount !== 'undefined' && OasisAccount.hasDiagnostic('heights')) {
+            // Skip diagnostic if user is not logged in or has already completed one for this phobia
+            if (typeof OasisAccount !== 'undefined' && (!OasisAccount.isLoggedIn() || OasisAccount.hasDiagnostic('heights'))) {
                 diagnosticScreen.style.display = 'none';
                 mainContent.classList.add('visible');
                 Ocean.init(mainContent);

--- a/minify/oasis-account.js
+++ b/minify/oasis-account.js
@@ -1749,8 +1749,8 @@ if (document.readyState === 'loading') {
                 closeBtn.addEventListener('click', function(e) {
                     var experience = getExperienceFromHash();
 
-                    // Show checkup if we're in an experience and haven't shown it yet
-                    if (experience && !checkupShown && typeof OasisAccount !== 'undefined') {
+                    // Show checkup if we're in an experience, haven't shown it yet, and user is logged in
+                    if (experience && !checkupShown && typeof OasisAccount !== 'undefined' && OasisAccount.isLoggedIn()) {
                         e.stopPropagation();
                         e.preventDefault();
                         checkupShown = true;


### PR DESCRIPTION
Users who are not logged in will now bypass both the initial diagnostic survey and the end-of-experience checkup survey, allowing them to directly access the experience content.

https://claude.ai/code/session_01Y2zn2kpR3pfpWtV9g3737W