### PR TITLE
Fix heights lobby camera: face elevator (inward) instead of city (out…

### DIFF
--- a/minify/heightsexperience.html
+++ b/minify/heightsexperience.html
@@ -821,7 +821,7 @@
                 skywalkGroup.visible = false;
                 cityGroup.visible = true;
                 camera.position.set(0, 1.7, 5);
-                euler.set(0, Math.PI, 0); // face the back wall (elevator)
+                euler.set(0, 0, 0); // face -Z toward the back wall (elevator)
                 camera.quaternion.setFromEuler(euler);
                 heightIndicator.textContent = 'Floor: Lobby';
                 showPrompt('Welcome to Skyline Tower.', 3000);
@@ -842,8 +842,8 @@
                     lobbyGroup.visible = false;
                     elevatorGroup.visible = true;
                     elevatorGroup.position.y = 0;
-                    camera.position.set(0, 1.7, 0.5);
-                    euler.set(0, Math.PI, 0); // facing back wall
+                    camera.position.set(0, 1.7, -0.5);
+                    euler.set(0, 0, 0); // facing glass front wall (outward view)
                     camera.quaternion.setFromEuler(euler);
                     State.canMove = false;
                     State.elevatorFloor = 0;
@@ -855,7 +855,7 @@
                         showPrompt('Going up...', 2000);
                         playDing();
                         // Let the player look around
-                        euler.set(-0.1, 0, 0); // slightly looking forward/down
+                        euler.set(-0.15, 0, 0); // slightly looking down to see city falling away
                         camera.quaternion.setFromEuler(euler);
                         State.transitioning = false;
                     }, 1500);


### PR DESCRIPTION
…ward)

- Lobby: euler from (0, PI, 0) to (0, 0, 0) so camera faces -Z toward elevator
- Elevator: camera moved to z=-0.5 facing glass front to see city during ascent
- Elevator tilt increased slightly to better show city falling away

https://claude.ai/code/session_019QW1f4CBpBM499Dpx4wgrj