### PR TITLE
Fix Three.js loading for local file:// protocol

### DIFF
--- a/presentation/city.html
+++ b/presentation/city.html
@@ -18,15 +18,9 @@
 </head>
 <body>
 <div id="info">Drag to orbit &middot; Scroll to zoom</div>
-<script type="importmap">
-{ "imports": {
-    "three": "https://unpkg.com/three@0.152.2/build/three.module.js",
-    "three/addons/": "https://unpkg.com/three@0.152.2/examples/jsm/"
-}}
-</script>
-<script type="module">
-import * as THREE from 'three';
-import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+<script src="https://unpkg.com/three@0.152.2/build/three.min.js"></script>
+<script src="https://unpkg.com/three@0.152.2/examples/js/controls/OrbitControls.js"></script>
+<script>
 (function() {
     // ── Scene setup ──
     var scene = new THREE.Scene();
@@ -46,7 +40,7 @@ import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
     renderer.toneMappingExposure = 1.2;
     document.body.appendChild(renderer.domElement);
 
-    var controls = new OrbitControls(camera, renderer.domElement);
+    var controls = new THREE.OrbitControls(camera, renderer.domElement);
     controls.enableDamping = true;
     controls.dampingFactor = 0.05;
     controls.maxPolarAngle = Math.PI / 2.2;

--- a/presentation/syringe.html
+++ b/presentation/syringe.html
@@ -18,15 +18,9 @@
 </head>
 <body>
 <div id="info">Drag to rotate &middot; Scroll to zoom</div>
-<script type="importmap">
-{ "imports": {
-    "three": "https://unpkg.com/three@0.152.2/build/three.module.js",
-    "three/addons/": "https://unpkg.com/three@0.152.2/examples/jsm/"
-}}
-</script>
-<script type="module">
-import * as THREE from 'three';
-import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+<script src="https://unpkg.com/three@0.152.2/build/three.min.js"></script>
+<script src="https://unpkg.com/three@0.152.2/examples/js/controls/OrbitControls.js"></script>
+<script>
 (function() {
     // ── Scene ──
     var scene = new THREE.Scene();
@@ -44,7 +38,7 @@ import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
     renderer.toneMappingExposure = 1.4;
     document.body.appendChild(renderer.domElement);
 
-    var controls = new OrbitControls(camera, renderer.domElement);
+    var controls = new THREE.OrbitControls(camera, renderer.domElement);
     controls.enableDamping = true;
     controls.dampingFactor = 0.05;
     controls.target.set(0, 0, 0);


### PR DESCRIPTION
ES modules with import maps have CORS restrictions when opened from file://. Switch to regular script tags with global THREE namespace which works reliably from downloaded HTML files.

https://claude.ai/code/session_019QW1f4CBpBM499Dpx4wgrj